### PR TITLE
Add cron setup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # rap
+
+## Setup
+
+Install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+Create a `.env` file in this directory with the following content:
+
+```ini
+OPENAI_API_KEY=your-api-key-here
+```
+
+## Running
+
+Execute the script manually:
+
+```bash
+python generate_rap.py
+```
+
+Alternatively, run the helper script to install dependencies and execute the
+program in one step:
+
+```bash
+./run.sh
+```
+
+To install the cron job automatically, pass `--install-cron`:
+
+```bash
+./run.sh --install-cron
+```
+
+## Schedule with cron
+
+If you prefer to add the job yourself, schedule it to run every 6 hours:
+
+```
+0 */6 * * * /usr/bin/python3 /path/to/generate_rap.py
+```

--- a/generate_rap.py
+++ b/generate_rap.py
@@ -1,0 +1,48 @@
+import os
+import csv
+from datetime import datetime
+
+import openai
+from dotenv import load_dotenv
+
+
+def generate_rap_song():
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY not found in environment")
+    openai.api_key = api_key
+
+    prompt = (
+        "Write a creative and emotionally expressive rap song with at least two verses "
+        "and either a chorus or a refrain. Format the output with section labels and clear line breaks."
+    )
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=500,
+            temperature=0.8,
+        )
+        lyrics = response.choices[0].message.content.strip()
+    except Exception:
+        # Fallback to text-davinci-003 if ChatCompletion fails
+        response = openai.Completion.create(
+            engine="text-davinci-003",
+            prompt=prompt,
+            max_tokens=500,
+            temperature=0.8,
+        )
+        lyrics = response.choices[0].text.strip()
+
+    timestamp = datetime.now().isoformat()
+    with open("rap_songs.csv", "a", newline="", encoding="utf-8") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow([timestamp, lyrics])
+
+    print("Rap song generated and saved.")
+
+
+if __name__ == "__main__":
+    generate_rap_song()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+python-dotenv

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Install dependencies and run the rap generator
+# Optional: pass --install-cron to schedule automatic runs every 6 hours
+set -e
+
+pip install --quiet --upgrade -r requirements.txt
+python generate_rap.py
+
+if [ "$1" == "--install-cron" ]; then
+    PYTHON=$(command -v python3)
+    SCRIPT_PATH=$(realpath generate_rap.py)
+    CRON_JOB="0 */6 * * * $PYTHON $SCRIPT_PATH"
+    (crontab -l 2>/dev/null | grep -Fv "$SCRIPT_PATH"; echo "$CRON_JOB") | crontab -
+    echo "Cron job installed: $CRON_JOB"
+fi


### PR DESCRIPTION
## Summary
- add optional cron setup in `run.sh`
- document cron installation in the README

## Testing
- `python -m py_compile generate_rap.py`
- `bash -n run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68802567e124832e8c6682c293c5f5cd